### PR TITLE
Lines on non-visible data fix

### DIFF
--- a/Aegean-Custom Studies.cpp
+++ b/Aegean-Custom Studies.cpp
@@ -103,6 +103,13 @@ SCSFExport scsf_GoogleSheetsLevelsImporter(SCStudyInterfaceRef sc)
     //Then we can check if the date of the line is > minimum date, otherwise ignore and do not draw
     //https://www.sierrachart.com/index.php?page=doc/ACSIL_Members_Variables_And_Arrays.html#scDaysToLoadInChart
 	
+    // get the number of days that are loaded into the chart
+    // get the date of the last data record in the array
+    // subtract days loaded from last data record date
+    // use new date as draw range
+    // this can be set via Chart >> Chart Settings >> Use Number of Days to Load >> Days to Load. (note: chart reload is required before changes are applied)
+    SCDateTime startDateDaysLoaded = sc.BaseDateTimeIn[sc.ArraySize - 1].AddDays(0 - sc.DaysToLoadInChart());
+	
     for (std::string line; getline(input,line);) {
         msg.Format("%s", line.c_str());
 
@@ -227,25 +234,19 @@ SCSFExport scsf_GoogleSheetsLevelsImporter(SCStudyInterfaceRef sc)
             }
 
             // draw line
-            if (i_DrawLinesOnChart.GetInt() == 1) {
-				Tool.ChartNumber = sc.ChartNumber;
-				if (beginDrawDateIndex == -1)
-				{
-					Tool.BeginDateTime = sc.BaseDateTimeIn[0];
-					Tool.EndDateTime = sc.BaseDateTimeIn[sc.ArraySize-1];
-				}
-				else
-				{
-					Tool.BeginDateTime = sc.BaseDateTimeIn[beginDrawDateIndex];
-					Tool.EndDateTime = sc.BaseDateTimeIn[endDrawDateIndex];
-				}
-                Tool.AddMethod = UTAM_ADD_OR_ADJUST;
-                Tool.ShowPrice = i_ShowPriceOnChart.GetInt();
-                Tool.TransparencyLevel = i_Transparency.GetInt();
-                Tool.Text = note;
-                Tool.LineNumber = LineNumber;
-                sc.UseTool(Tool);
-            }
+	    if (beginDrawDateIndex != -1) {
+	        if (i_DrawLinesOnChart.GetInt() == 1) {
+		    Tool.ChartNumber = sc.ChartNumber;
+		    Tool.BeginDateTime = sc.BaseDateTimeIn[beginDrawDateIndex];
+		    Tool.EndDateTime = sc.BaseDateTimeIn[endDrawDateIndex];
+		    Tool.AddMethod = UTAM_ADD_OR_ADJUST;
+		    Tool.ShowPrice = i_ShowPriceOnChart.GetInt();
+		    Tool.TransparencyLevel = i_Transparency.GetInt();
+		    Tool.Text = note;
+		    Tool.LineNumber = LineNumber;
+		    sc.UseTool(Tool);
+	   	}
+	    }
 
             idx++;
         }


### PR DESCRIPTION
In order to draw the lines on a certain point, we're using a 'beginDrawDateIndex' and an 'endDrawDateIndex'. This index references a set of values in our data-set (array). When looping through the data set, we take the date value of each data-record and compare it to the date set in Google Sheets. Given that the array is sorted, the index of the first matching item is set as the beginDrawDateIndex. We continue through the loop and set the endDrawDateIndex for every next match. This means that once the date no longer matches, the endDrawDateIndex will no longer be set, leaving us with the index of the last matching data value.

With the above in mind: We'd initially programmed the drawing of lines with a fallback, that if a date was not set, a default value would be used. The default value has now been removed, which should remove some -if not all- of the excess lines in the chart.

Additionally, a startDateDaysLoaded variable has been introduced as an extra check. This value is used to compare against the date on the data record, and will refrain from drawing a line on this record if the record is outside of the view. The value is set by taking the BaseDateTimeIn of the last data record, and subtracting the DaysToLoadInChart.